### PR TITLE
グループメンバーのインクリメンタルサーチの実装

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,18 +1,21 @@
 $(function() {
-  function addUser(user){
-    var html = `
-              <div class="chat-group-user clearfix">
-                <p class="chat-group-user__name">ユーザー名</p>
-                <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id=${user.id}" data-user-name="${user.name}">追加</div>
-              </div>
-              `
+  function addUser(user) {
+    let html = `
+      <div class="chat-group-user clearfix">
+        <p class="chat-group-user__name">${user.name}</p>
+        <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.id}" data-user-name="${user.name}">追加</div>
+      </div>
+    `;
+    $("#user-search-result").append(html);
   }
 
-  function addNoUser(user){
-    var html = `
-              <div class="chat-group-user cleafix">
-                <p class="chat-group-user__name">ユーザーがみつかりません</p>
-              <div>`
+  function addNoUser(){
+    let html = `
+      <div class="chat-group-user cleafix">
+        <p class="chat-group-user__name">ユーザーがみつかりません</p>
+      <div>
+    `;
+    $("#user-search-result").append(html);
   }
 
   $("#user-search-field").on("keyup", function() {

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,0 +1,6 @@
+$(function() {
+  $("#user-search-field").on("keyup", function() {
+    let input = $("#user-search-field").val();
+    console.log(input); 
+  });
+});

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -17,6 +17,18 @@ $(function() {
     `;
     $("#user-search-result").append(html);
   }
+  function addDeleteUser(name, id) {
+    let html = `
+      <div class="chat-group-user clearfix" id="${id}">
+        <p class="chat-group-user__name">${name}</p>
+        <div class="user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn" data-user-id="${id}" data-user-name="${name}">削除</div>
+      </div>`;
+      $(".js-add-user").append(html);
+  }
+  function addMember(userId) {
+    let html = `<input value="${userId}" name="group[user_ids][]" type="hidden" id="group_user_ids_${userId}" />`;
+    $(`#${userId}`).append(html);
+  }
 
   $("#user-search-field").on("keyup", function() {
     let input = $("#user-search-field").val();
@@ -45,6 +57,18 @@ $(function() {
       });
   });
   $(document).on("click", ".chat-group-user__btn--add", function() {
-    console.log("イベント発火成功");
-  })
+    console.log
+    const userName = $(this).attr("data-user-name");
+    const userId = $(this).attr("data-user-id");
+    $(this)
+      .parent()
+      .remove();
+    addDeleteUser(userName, userId);
+    addMember(userId);
+  });
+  $(document).on("click", ".chat-group-user__btn--remove", function() {
+      $(this)
+        .parent()
+        .remove();
+  });
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,4 +1,20 @@
 $(function() {
+  function addUser(user){
+    var html = `
+              <div class="chat-group-user clearfix">
+                <p class="chat-group-user__name">ユーザー名</p>
+                <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id=${user.id}" data-user-name="${user.name}">追加</div>
+              </div>
+              `
+  }
+
+  function addNoUser(user){
+    var html = `
+              <div class="chat-group-user cleafix">
+                <p class="chat-group-user__name">ユーザーがみつかりません</p>
+              <div>`
+  }
+
   $("#user-search-field").on("keyup", function() {
     let input = $("#user-search-field").val();
 
@@ -9,10 +25,20 @@ $(function() {
       data: { keyword: input }
     })
       .done(function(users) {
-        console.log("成功です");
+        $("#user-search-result").empty();
+
+        if (users.length !== 0) {
+          users.forEach(function(user) {
+            addUser(user);
+          });
+        } else if (input.length == 0) {
+          return false;
+        } else {
+          addNoUser();
+        }
       })
       .fail(function() {
-        console.log("失敗です");
+        alert("通信エラーです。ユーザーが表示できません。");
       });
   });
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,6 +1,18 @@
 $(function() {
   $("#user-search-field").on("keyup", function() {
     let input = $("#user-search-field").val();
-    console.log(input); 
+
+    $.ajax({
+      type: "GET",
+      url: "/users",
+      dataType: "json",
+      data: { keyword: input }
+    })
+      .done(function(users) {
+        console.log("成功です");
+      })
+      .fail(function() {
+        console.log("失敗です");
+      });
   });
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -44,4 +44,7 @@ $(function() {
         alert("通信エラーです。ユーザーが表示できません。");
       });
   });
+  $(document).on("click", ".chat-group-user__btn--add", function() {
+    console.log("イベント発火成功");
+  })
 });

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,13 @@ class UsersController < ApplicationController
   def edit
   end
 
+  def index
+    resond_to do |format|
+      format.html
+      format.json
+    end
+  end
+
   def update
     if current_user.update(user_params)
       redirect_to root_path

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,13 +1,13 @@
 class UsersController < ApplicationController
-  
-  def edit
-  end
 
   def index
     resond_to do |format|
       format.html
       format.json
     end
+  end
+
+  def edit
   end
 
   def update

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,9 @@
 class UsersController < ApplicationController
 
   def index
-    resond_to do |format|
+    return nil if params[:keyword] == ""
+    @users = User.where(['name LIKE ?', "%#{params[:keyword]}%"] ).where.not(id: current_user.id).limit(10)
+    respond_to do |format|
       format.html
       format.json
     end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -10,15 +10,23 @@
       = f.label :name, class: 'chat-group-form__label'
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
-  .chat-group-form__field.clearfix
-    / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
+  .chat-group-form__field
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+    .chat-group-form__field--right
+      .chat-group-form__search.clearfix
+        %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+      #user-search-result
+      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       = f.label "チャットメンバー", class: "chat-group-form__labell"
     .chat-group-form__field--right
       / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
+      /= f.collection_check_boxes :user_ids, User.all, :id, :name
       / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
+      #chat-group-users.js-add-user
+      
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -11,27 +11,33 @@
       = f.label :name, class: 'chat-group-form__label'
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
-
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
-      /= f.label :users, "チャットメンバーを追加", class: 'chat-group-form_label', for: 'user-search-field'
       %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
     .chat-group-form__field--right
       .chat-group-form__search.clearfix
-        /= f.text_field :users, id: 'user-search-field', class: 'chat-group-form__input', value: '', placeholder: '追加したいユーザー名を入力してください'
         %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
       #user-search-result
 
-    / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
-      /= f.label "チャットメンバー", class: "chat-group-form__labell"
     .chat-group-form__field--right
+
       #chat-group-users.js-add-user
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      /= f.collection_check_boxes :user_ids, User.all, :id, :name
-      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
+        .chat-group-user.clearfix.js-chat-member
+          %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
+          %p.chat-group-user__name= current_user.name
+
+        -group.users.each do |user|
+          -if current_user.name != user.name
+            .chat-group-user.clearfix.js-chat-member
+              %input{name: "group[user_ids][]", type: "hidden", value: user.id}
+              %p.chat-group-user__name
+                = user.name
+              %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn
+                削除
+                
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -5,28 +5,33 @@
       %ul
         - group.errors.full_messages.each do |message|
           %li = message
+  
   .chat-group-form__field
     .chat-group-form__field--left
       = f.label :name, class: 'chat-group-form__label'
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
-  .chat-group-form__field
+
+  .chat-group-form__field.clearfix
     .chat-group-form__field--left
+      /= f.label :users, "チャットメンバーを追加", class: 'chat-group-form_label', for: 'user-search-field'
       %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
     .chat-group-form__field--right
       .chat-group-form__search.clearfix
+        /= f.text_field :users, id: 'user-search-field', class: 'chat-group-form__input', value: '', placeholder: '追加したいユーザー名を入力してください'
         %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
       #user-search-result
-      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
+
+    / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
-      = f.label "チャットメンバー", class: "chat-group-form__labell"
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+      /= f.label "チャットメンバー", class: "chat-group-form__labell"
     .chat-group-form__field--right
+      #chat-group-users.js-add-user
       / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
       /= f.collection_check_boxes :user_ids, User.all, :id, :name
       / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
-      #chat-group-users.js-add-user
-      
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end


### PR DESCRIPTION
# What
テキストフィールドに入力される度にイベントが発火するようにして非同期通信を出来るようにする
非同期通信の結果を得て、HTMLを作成し、それをビュー上に追加する。
エラー時の処理を行う。
追加ボタンが押された時にイベントが発火するようにしてユーザーの名前をチャットメンバーの部分に追加し、検索結果から消す。
削除ボタンを押すと、チャットメンバーから削除される
ログイン中のユーザーを追加済みの状態にする。
編集画面では既存のユーザーが追加済みの状態であることを確認する。

# Why
チャットグループ作成時のメンバー追加時にインクリメンタルサーチを導入することに寄ってチャットグループ作成時のメンバー追加を容易にする。