### PR TITLE
チャット画面自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,8 +1,8 @@
 $(function(){ 
     function buildHTML(message){
-      var addimage = ( message.image !== null ) ? `<img class = class: "lower-message__image", src="${message.image}">` : ''
+      var addimage = ( message.image.url !== null ) ? `<img class = class: "lower-message__image", src="${message.image.url}">` : ''
         var html =
-          `<div class="message" data-message-id=${message.id}>
+          `<div class="message" data-message-id="${message.id}">
             <div class="upper-message">
                <div class="upper-message__user-name">
                  ${message.user_name}
@@ -15,8 +15,8 @@ $(function(){
               <p class="lower-message__content">
                 ${message.content}
               </p>
+              ${addimage}
             </div>
-            ${addimage}
           </div>`
         return html;
       } 
@@ -43,4 +43,21 @@ $('#new_message.new_message').on('submit', function(e){
       });
       return false;
 })
+
+    var reloadMessages = function() {
+      last_message_id = $('.message:last').data("message-id"); 
+
+      $.ajax({
+        url: "api/messages",
+        type: 'get',
+        dataType: 'json',
+        data: {last_id: last_message_id}
+      })
+      .done(function(messages) {
+        console.log('success');
+      })
+      .fail(function() {
+        console.log('error');
+      });
+    };
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -45,26 +45,27 @@ $('#new_message.new_message').on('submit', function(e){
 })
 
     var reloadMessages = function() {
-      
-      last_message_id = $('.message:last').data("message-id"); 
+      if (window.location.href.match(/\/groups\/\d+\/messages/)){
+        var last_message_id = $('.message:last').data("message-id"); 
 
-      $.ajax({
-        url: "api/messages",
-        type: 'get',
-        dataType: 'json',
-        data: {last_id: last_message_id}
-      })
-      .done(function(messages) {
-        var insertHTML = '';
-        messages.forEach(function(message) {
-          insertHTML = buildHTML(message);
-          $('.messages').append(insertHTML);
+        $.ajax({
+          url: "api/messages",
+          type: 'get',
+          dataType: 'json',
+          data: {last_id: last_message_id}
         })
-        $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
-      })
-      .fail(function() {
-        console.log('error');
-      });
+        .done(function(messages) {
+          var insertHTML = '';
+          messages.forEach(function(message) {
+            insertHTML = buildHTML(message);
+            $('.messages').append(insertHTML);
+          })
+          $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
+        })
+        .fail(function() {
+          alert('自動更新に失敗しました');
+        });
+      }
     };
     setInterval(reloadMessages, 5000);
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -65,4 +65,5 @@ $('#new_message.new_message').on('submit', function(e){
         console.log('error');
       });
     };
+    setInterval(reloadMessages, 5000);
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -60,6 +60,7 @@ $('#new_message.new_message').on('submit', function(e){
           insertHTML = buildHTML(message);
           $('.messages').append(insertHTML);
         })
+        $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
       })
       .fail(function() {
         console.log('error');

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -45,6 +45,7 @@ $('#new_message.new_message').on('submit', function(e){
 })
 
     var reloadMessages = function() {
+      
       last_message_id = $('.message:last').data("message-id"); 
 
       $.ajax({
@@ -54,7 +55,11 @@ $('#new_message.new_message').on('submit', function(e){
         data: {last_id: last_message_id}
       })
       .done(function(messages) {
-        console.log('success');
+        var insertHTML = '';
+        messages.forEach(function(message) {
+          insertHTML = buildHTML(message);
+          $('.messages').append(insertHTML);
+        })
       })
       .fail(function() {
         console.log('error');

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -11,9 +11,9 @@ $(function() {
 
   function addNoUser(){
     let html = `
-      <div class="chat-group-user cleafix">
+      <div class="chat-group-user clearfix">
         <p class="chat-group-user__name">ユーザーがみつかりません</p>
-      <div>
+      </div>
     `;
     $("#user-search-result").append(html);
   }

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @messages do |message|
   json.content message.content
   json.image message.image
-  json.created_at message.created_at
+  json.created_at message.created_at.strftime("%Y/%m/%d %H:%M")
   json.user_name message.user.name
   json.id message.id
 end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image
+  json.created_at message.created_at
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,11 +1,11 @@
 = form_for group do |f|
   - if group.errors.any?
     .chat-group-form__errors
-      %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました。"
+      %h2= "#{group.errors.full_messages.count}件のエラーが発生しました。"
       %ul
         - group.errors.full_messages.each do |message|
-          %li = message
-  
+          %li= message
+
   .chat-group-form__field
     .chat-group-form__field--left
       = f.label :name, class: 'chat-group-form__label'
@@ -29,15 +29,15 @@
           %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
           %p.chat-group-user__name= current_user.name
 
-        -group.users.each do |user|
-          -if current_user.name != user.name
+        - group.users.each do |user|
+          - if current_user.name != user.name
             .chat-group-user.clearfix.js-chat-member
               %input{name: "group[user_ids][]", type: "hidden", value: user.id}
               %p.chat-group-user__name
                 = user.name
               %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn
                 削除
-                
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{"data-message-id": "#{message.id}"}
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -3,3 +3,6 @@ json.user_name @message.user.name
 json.date @message.created_at.strftime("%Y/%m/%d %H:%M")
 json.content @message.content
 json.image @message.image_url
+
+json.(@message, :content, :image)
+json.created_at @message.created_at

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
_message.html.hamlにid情報を追加しカスタムデータを設定
メッセージを更新するためのアクションを実装
追加したアクションを動かくためのルーティングを実装、追加したアクションをリクエストするよう実装
取得した最新のメッセージをブラウザのメッセージ一覧に追加。
数秒ごとにリクエストするよう実装しメッセージ分だけスクロールするよう実装
メッセージ一覧のページのみJSが動くよう実装

# Why
現在は自分の投稿は非同期通信で表示されているが、
別のユーザーが別の画面から投稿したメッセージはリロードしないと表示されないので
チャットらしく自動で更新されるようにする。

![capture20191105](https://user-images.githubusercontent.com/56674060/68200865-0ca17b00-0004-11ea-8360-bbea04e59481.gif)
